### PR TITLE
Prune during AbstractGitSCMSource fetch

### DIFF
--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -8,12 +8,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.WithoutJenkins;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link AbstractGitSCMSource}
@@ -25,38 +21,6 @@ public class AbstractGitSCMSourceTest {
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
   
-  /*
-   * Test excluded branches
-   * TODO seems to overlap AbstractGitSCMSourceTrivialTest.testIsExcluded
-   */
-  @WithoutJenkins // unnecessary if moved into, say, AbstractGitSCMSourceTrivialTest
-  @Test
-  public void basicTestIsExcluded(){
-    AbstractGitSCMSource abstractGitSCMSource = mock(AbstractGitSCMSource.class);
-    
-    when(abstractGitSCMSource.getIncludes()).thenReturn("*master release* fe?ture");
-    when(abstractGitSCMSource.getExcludes()).thenReturn("release bugfix*");
-    when(abstractGitSCMSource.isExcluded(Mockito.anyString())).thenCallRealMethod();
-    
-    assertFalse(abstractGitSCMSource.isExcluded("master"));
-    assertFalse(abstractGitSCMSource.isExcluded("remote/master"));
-    assertFalse(abstractGitSCMSource.isExcluded("release/X.Y"));
-    assertFalse(abstractGitSCMSource.isExcluded("releaseX.Y"));
-    assertFalse(abstractGitSCMSource.isExcluded("fe?ture"));
-    assertTrue(abstractGitSCMSource.isExcluded("feature"));
-    assertTrue(abstractGitSCMSource.isExcluded("release"));
-    assertTrue(abstractGitSCMSource.isExcluded("bugfix"));
-    assertTrue(abstractGitSCMSource.isExcluded("bugfix/test"));
-    assertTrue(abstractGitSCMSource.isExcluded("test"));
-
-    when(abstractGitSCMSource.getIncludes()).thenReturn("master feature/*");
-    when(abstractGitSCMSource.getExcludes()).thenReturn("feature/*/private");
-    assertFalse(abstractGitSCMSource.isExcluded("master"));
-    assertTrue(abstractGitSCMSource.isExcluded("devel"));
-    assertFalse(abstractGitSCMSource.isExcluded("feature/spiffy"));
-    assertTrue(abstractGitSCMSource.isExcluded("feature/spiffy/private"));
-  }
-
     // TODO AbstractGitSCMSourceRetrieveHeadsTest *sounds* like it would be the right place, but it does not in fact retrieve any heads!
     @Issue("JENKINS-37482")
     @Test

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTrivialTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTrivialTest.java
@@ -4,8 +4,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
-import hudson.plugins.git.browser.GitRepositoryBrowser;
-import hudson.plugins.git.extensions.GitSCMExtension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +14,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 import org.junit.Before;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.*;
 
 public class AbstractGitSCMSourceTrivialTest {
 
@@ -37,6 +37,33 @@ public class AbstractGitSCMSourceTrivialTest {
             expectedRefSpecs.add(new RefSpec(expectedRefSpec));
         }
         gitSCMSource = new AbstractGitSCMSourceImpl();
+    }
+
+    @Test
+    public void basicTestIsExcluded() {
+        AbstractGitSCMSource abstractGitSCMSource = mock(AbstractGitSCMSource.class);
+
+        when(abstractGitSCMSource.getIncludes()).thenReturn("*master release* fe?ture");
+        when(abstractGitSCMSource.getExcludes()).thenReturn("release bugfix*");
+        when(abstractGitSCMSource.isExcluded(Mockito.anyString())).thenCallRealMethod();
+
+        assertFalse(abstractGitSCMSource.isExcluded("master"));
+        assertFalse(abstractGitSCMSource.isExcluded("remote/master"));
+        assertFalse(abstractGitSCMSource.isExcluded("release/X.Y"));
+        assertFalse(abstractGitSCMSource.isExcluded("releaseX.Y"));
+        assertFalse(abstractGitSCMSource.isExcluded("fe?ture"));
+        assertTrue(abstractGitSCMSource.isExcluded("feature"));
+        assertTrue(abstractGitSCMSource.isExcluded("release"));
+        assertTrue(abstractGitSCMSource.isExcluded("bugfix"));
+        assertTrue(abstractGitSCMSource.isExcluded("bugfix/test"));
+        assertTrue(abstractGitSCMSource.isExcluded("test"));
+
+        when(abstractGitSCMSource.getIncludes()).thenReturn("master feature/*");
+        when(abstractGitSCMSource.getExcludes()).thenReturn("feature/*/private");
+        assertFalse(abstractGitSCMSource.isExcluded("master"));
+        assertTrue(abstractGitSCMSource.isExcluded("devel"));
+        assertFalse(abstractGitSCMSource.isExcluded("feature/spiffy"));
+        assertTrue(abstractGitSCMSource.isExcluded("feature/spiffy/private"));
     }
 
     @Test


### PR DESCRIPTION
Need for separate prune is removed by switching from deprecated fetch()
method to fetch_() method.

[Fix JENKINS-37727] CliGit leaves deleted branches in multi-branch jobs