### PR TITLE
Remove duplicate and unhelpful tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.36</version>
+    <version>2.33</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Parameter combining is a fundamental Jenkins core behavior, not
something that needs specific testing in the git plugin.

Retains the one test in the class which used git operations.