### PR TITLE
JENKINS-24483 - Fix repository browser validators

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -95,16 +95,15 @@ public class AssemblaWeb extends GitRepositoryBrowser {
             return req.bindJSON(AssemblaWeb.class, jsonObject);
         }
 
-        public FormValidation doCheckUrl(@QueryParameter(fixEmpty = true) final String url)
+        public FormValidation doCheckRepoUrl(@QueryParameter(fixEmpty = true) final String value)
                 throws IOException, ServletException {
-            if (url == null) // nothing entered yet
-            {
+            if (value == null) { // nothing entered yet
                 return FormValidation.ok();
             }
             return new URLCheck() {
                 @Override
                 protected FormValidation check() throws IOException, ServletException {
-                    String v = url;
+                    String v = value;
                     if (!v.endsWith("/")) {
                         v += '/';
                     }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -8,7 +8,6 @@ import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
-import hudson.scm.browsers.QueryBuilder;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -16,10 +15,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
 
 /**
  * AssemblaWeb Git Browser URLs
@@ -44,6 +40,9 @@ public class AssemblaWeb extends GitRepositoryBrowser {
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
         URL url = getUrl();
+        if (url == null) {
+            return null;
+        }
         return new URL(url, url.getPath() + "commits/" + changeSet.getId());
     }
 
@@ -74,6 +73,9 @@ public class AssemblaWeb extends GitRepositoryBrowser {
     public URL getFileLink(Path path) throws IOException {
         GitChangeSet changeSet = path.getChangeSet();
         URL url = getUrl();
+        if (url == null) {
+            return null;
+        }
         if (path.getEditType() == EditType.DELETE) {
             return new URL(url, url.getPath() + "nodes/" + changeSet.getParentCommit() + path.getPath());
         } else {

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -85,6 +85,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class AssemblaWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
+        @Override
         public String getDisplayName() {
             return "AssemblaWeb";
         }
@@ -101,6 +102,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             return new URLCheck() {
+                @Override
                 protected FormValidation check() throws IOException, ServletException {
                     String v = url;
                     if (!v.endsWith("/")) {

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -15,22 +15,22 @@ import java.net.URL;
 
 public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSet> {
 
-    private /* mostly final */ String url;
+    private /* mostly final */ String repoUrl;
 
     @Deprecated
     protected GitRepositoryBrowser() {
     }
 
-    protected GitRepositoryBrowser(String repourl) {
-        this.url = repourl;
+    protected GitRepositoryBrowser(String repoUrl) {
+        this.repoUrl = repoUrl;
     }
 
     public final String getRepoUrl() {
-        return url;
+        return repoUrl;
     }
 
     public final URL getUrl() throws IOException {
-        String u = url;
+        String u = repoUrl;
         if (u == null || u.trim().isEmpty()) {
             return null;
         }
@@ -44,7 +44,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
                 } catch (InterruptedException e) {
                     throw new IOException("Failed to retrieve job environment", e);
                 }
-                u = env.expand(url);
+                u = env.expand(repoUrl);
             }
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -31,6 +31,9 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
 
     public final URL getUrl() throws IOException {
         String u = url;
+        if (u == null || u.trim().isEmpty()) {
+            return null;
+        }
         StaplerRequest req = Stapler.getCurrentRequest();
         if (req != null) {
             Job job = req.findAncestorObject(Job.class);

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.junit.Test;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
 
 @RunWith(Parameterized.class)
 public class AssemblaWebTest {
@@ -42,6 +44,20 @@ public class AssemblaWebTest {
     }
 
     @Test
+    @Issue("JENKINS-24483")
+    public void testGetChangeSetLink_EmptyRepoURL() throws Exception {
+        URL result = (new AssemblaWeb("")).getChangeSetLink(sample.changeSet);
+        assertThat(result, is(nullValue(URL.class)));
+    }
+
+    @Test
+    @Issue("JENKINS-24483")
+    public void testGetChangeSetLink_InvalidRepoURL() throws Exception {
+        URL result = (new AssemblaWeb("this is truly not a URL")).getChangeSetLink(sample.changeSet);
+        assertThat(result, is(nullValue(URL.class)));
+    }
+
+    @Test
     public void testGetDiffLink() throws Exception {
         AssemblaWeb assemblaWeb = new AssemblaWeb(repoUrl);
         for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
@@ -50,6 +66,30 @@ public class AssemblaWebTest {
             URL expectedDiffLink = new URL(repoUrl + "commits/" + sample.id);
             String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
             assertEquals(msg, expectedDiffLink, diffLink);
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-24483")
+    public void testGetDiffLink_EmptyURL() throws Exception {
+        AssemblaWeb assemblaWeb = new AssemblaWeb("");
+        for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
+            URL diffLink = assemblaWeb.getDiffLink(path);
+            EditType editType = path.getEditType();
+            String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
+            assertThat(msg, diffLink, is(nullValue()));
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-24483")
+    public void testGetDiffLink_InvalidURL() throws Exception {
+        AssemblaWeb assemblaWeb = new AssemblaWeb("another string that isn't a valid URL");
+        for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
+            URL diffLink = assemblaWeb.getDiffLink(path);
+            EditType editType = path.getEditType();
+            String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
+            assertThat(msg, diffLink, is(nullValue()));
         }
     }
 
@@ -72,4 +112,27 @@ public class AssemblaWebTest {
         }
     }
 
+    @Test
+    @Issue("JENKINS-24483")
+    public void testGetFileLink_EmptyRepoURL() throws Exception {
+        AssemblaWeb assemblaWeb = new AssemblaWeb("");
+        for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
+            URL fileLink = assemblaWeb.getFileLink(path);
+            EditType editType = path.getEditType();
+            String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
+            assertThat(msg, fileLink, is(nullValue()));
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-24483")
+    public void testGetFileLink_InvalidRepoURL() throws Exception {
+        AssemblaWeb assemblaWeb = new AssemblaWeb("this is not a URL");
+        for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
+            URL fileLink = assemblaWeb.getFileLink(path);
+            EditType editType = path.getEditType();
+            String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
+            assertThat(msg, fileLink, is(nullValue()));
+        }
+    }
 }

--- a/src/test/java/hudson/plugins/git/browser/GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitRepositoryBrowserTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
 
 @RunWith(Parameterized.class)
 public class GitRepositoryBrowserTest {
@@ -119,12 +120,21 @@ public class GitRepositoryBrowserTest {
         return new URL(baseURL + path.getPath() + (isDiffLink ? "-diff-link" : "-file-link"));
     }
 
+    @Test
+    @Issue("JENKINS-24483") // Logged an exception instead of returning null URL
+    public void testGetUrl() throws Exception {
+        URL result = browser.getUrl();
+        assertThat(result, is(nullValue()));
+    }
+
     public class GitRepositoryBrowserImpl extends GitRepositoryBrowser {
 
+        @Override
         public URL getDiffLink(GitChangeSet.Path path) throws IOException {
             return getURL(path, true);
         }
 
+        @Override
         public URL getFileLink(GitChangeSet.Path path) throws IOException {
             return getURL(path, false);
         }


### PR DESCRIPTION
[JENKINS-24483](https://issues.jenkins-ci.org/browse/JENKINS-24483) notes that frequent and annoying stack traces are created in the Jenkins log if a job is configured with a repository browser that has an empty Git repository browser URL field.

Field validation is implemented in the git plugin for that browser field, but is not being called due to a naming mismatch between the field and the validation method.

Callers are expecting a URL or null, and instead the code is throwing a URL exception due to the invalid URL.

Before this pull request is merged, it should:

* [ ] return null when URL is invalid instead of throwing an exception
* [ ] test the URL validation methods interactively
* [ ] test the URL validation methods with automation
* [ ] confirm that compatibility is retained for the changes