### PR TITLE
waitForTagCreation calls moved to immediately after each createTagAction

### DIFF
--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -112,11 +112,13 @@ public class GitTagActionTest {
         /* Run with first tag action defined */
         tagOneAction = createTagAction("v1");
 
+        /* Wait for tag creation threads to complete, then assert conditions */
+        waitForTagCreation(tagOneAction, "v1");
+
         /* Run with second tag action defined */
         tagTwoAction = createTagAction("v2");
 
         /* Wait for tag creation threads to complete, then assert conditions */
-        waitForTagCreation(tagOneAction, "v1");
         waitForTagCreation(tagTwoAction, "v2");
 
         assertThat(getMatchingTagNames(), hasItems(getTagValue("v1"), getTagValue("v2")));


### PR DESCRIPTION
This is done to avoid potential race conditions that would make asserts in waitForTagCreation fail if tags are created in the opposite order

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No findbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Please refer to this comment: https://github.com/jenkinsci/git-plugin/pull/667#pullrequestreview-197246342